### PR TITLE
Add Neurolink - Multi-Provider AI Agent Framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,20 @@ suggestion, feel free to open an issue or pull request. (Last updated: 2025-10-1
   - Built-in action validation
 
 
+- [Neurolink](https://github.com/juspay/neurolink) - Multi-provider AI agent framework
+  with workflow orchestration capabilities, unifying 12+ providers (OpenAI, Google,
+  Anthropic, AWS, Azure, Groq, Together AI, Mistral, Cohere, Fireworks, Cloudflare,
+  Ollama)
+
+  STARS · FORKS · CONTRIBUTORS · ISSUES · TypeScript · MIT
+
+  - Multi-agent framework with workflow orchestration
+  - Unified interface for 12+ AI providers
+  - Edge-first architecture with local/cloud deployment
+  - Production-grade streaming and tool calling
+  - Battle-tested at Juspay (15M+ requests/month)
+
+
 - [OpenAgents](https://github.com/xlang-ai/OpenAgents) - Open platform for language
   agents
 


### PR DESCRIPTION
## Adding Neurolink Framework

**Neurolink** is a production-grade multi-provider AI agent framework that belongs alongside frameworks like LangChain, CrewAI, and AutoGen.

- **Repository**: https://github.com/juspay/neurolink
- **Category**: Multi-agent framework with workflow orchestration
- **Languages**: TypeScript (SDK + CLI)
- **License**: MIT
- **Production**: 15M+ requests/month at Juspay

### Key Differentiators:
- Multi-agent framework with workflow orchestration capabilities
- Unifies 12+ AI providers (OpenAI, Google, Anthropic, AWS, Azure, Groq, Together AI, Mistral, Cohere, Fireworks, Cloudflare, Ollama)
- Edge-first architecture for local/cloud deployment
- Enterprise features: Redis caching, proxy support, telemetry
- Production-tested at scale

Neurolink complements existing frameworks by providing multi-provider agent capabilities with workflow orchestration.