### PR TITLE
Add Quorum - multi-agent AI discussion system

### DIFF
--- a/README.md
+++ b/README.md
@@ -484,3 +484,15 @@ suggestion, feel free to open an issue or pull request. (Last updated: 2025-12-0
   - Adaptive agent search framework
   - Unified framework for six agent tasks
   - Tsinghua University research project
+
+
+- [Quorum](https://github.com/Detrol/quorum-cli) - Multi-agent AI discussion system for
+  structured debates
+
+  Python · BSL-1.1
+
+  - 7 discussion methods: Standard, Oxford, Socratic, Delphi, Brainstorm, Tradeoff, Advocate
+  - Multi-phase consensus: independent answers → critique → discussion → synthesis
+  - Supports Claude, GPT, Gemini, Grok, and local Ollama models
+  - Terminal UI with real-time streaming
+  - Auto-discovery of local Ollama models


### PR DESCRIPTION
Adding [Quorum](https://github.com/Detrol/quorum-cli) - a multi-agent AI discussion CLI.

**What it does:**
- Orchestrates structured debates between AI models (Claude, GPT, Gemini, Grok, Ollama)
- 7 discussion methods: Standard, Oxford-style debate, Devil's Advocate, Socratic dialogue, Delphi estimation, Brainstorm, and Tradeoff analysis
- Multi-phase consensus building with independent answers → critique → discussion → synthesis
- Supports local models via Ollama auto-discovery
- Terminal UI with real-time streaming

Thanks for maintaining this awesome list!