### PR TITLE
Add Openwork to Frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -467,3 +467,14 @@ suggestion, feel free to open an issue or pull request. (Last updated: 2026-01-1
   - Adaptive agent search framework
   - Unified framework for six agent tasks
   - Tsinghua University research project
+
+- [Openwork](https://github.com/accomplish-ai/openwork) - MIT-licensed, open alternative
+  to Anthropic's Cowork for browser automation
+
+  1,891 stars · 283 forks · TypeScript · MIT
+
+  - Multi-provider LLM support
+  - Computer-use agent automation
+  - Built on Opencode and dev-browser
+  - Real browser workflow automation
+  - Fully open source


### PR DESCRIPTION
## Summary
- Adds [Openwork](https://github.com/accomplish-ai/openwork) to the Frameworks section

## About Openwork
Openwork is an MIT-licensed, open alternative to Anthropic's Cowork, built using [Opencode](https://github.com/anomalyco/opencode) and [dev-browser](https://github.com/SawyerHood/dev-browser). It supports multiple LLM providers and lets users launch computer-use agents to automate real browser workflows—faster, safer, and fully open source.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)