### PR TITLE
Add Lava AI Spend to Tools / Infrastructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -461,3 +461,14 @@ suggestion, feel free to open an issue or pull request. (Last updated: 2026-02-0
   - Adaptive agent search framework
   - Unified framework for six agent tasks
   - Tsinghua University research project
+
+
+## Tools / Infrastructure
+
+- [Lava AI Spend](https://lava.so) - Per-tool budget controls and spend limits
+  for AI API keys
+
+  - Hard spend limits per key
+  - Model restrictions and instant revoke
+  - 38+ provider support via OpenAI-compatible endpoint
+  - Cost tracking and usage monitoring


### PR DESCRIPTION
Add [Lava AI Spend](https://lava.so) under a new Tools / Infrastructure section.

Lava AI Spend provides per-tool budget controls and spend limits for AI API keys. It supports 38+ providers through a single OpenAI-compatible endpoint, letting teams create isolated keys with hard spend limits, model restrictions, and instant revoke.