### PR TITLE
Add Wee-Orchestrator — multi-runtime AI agent orchestrator

### DIFF
--- a/README.md
+++ b/README.md
@@ -623,3 +623,17 @@ suggestion, feel free to open an issue or pull request. (Last updated: 2026-02-2
   - Supports Claude, GPT, Gemini, Grok, and local Ollama models
   - Terminal UI with real-time streaming
   - Auto-discovery of local Ollama models
+
+
+- [Wee-Orchestrator](https://github.com/leprachuan/Wee-Orchestrator) - Self-hosted multi-agent
+  AI orchestrator for Claude, Gemini, and Copilot CLI
+
+  3 stars · 0 forks · 1 contributor · 12 issues · Python · GPL-3.0
+
+  - 5 AI runtimes: Copilot CLI, Claude Code, OpenCode, Gemini, Codex
+  - 3 channels: Telegram bot, WebEx bot (RabbitMQ), glassmorphism Web UI
+  - Multi-agent with per-task agent switching via slash commands
+  - Built-in task scheduler with natural language scheduling
+  - Extensible skill plugin architecture (Cisco Meraki, Home Assistant, etc.)
+  - Background task delegation to sub-agents
+  - Secure pairing-code auth with per-user ACLs


### PR DESCRIPTION
## Wee-Orchestrator

**GitHub:** https://github.com/leprachuan/Wee-Orchestrator
**License:** GPL-3.0 | **Language:** Python

Self-hosted multi-agent AI orchestrator that coordinates 5 AI CLI runtimes (Claude Code, Copilot CLI, OpenCode, Gemini, Codex) across 3 communication channels (Telegram, WebEx, browser Web UI).

### Unique differentiators:
- **Multi-runtime** — only orchestrator supporting Claude + Gemini + Copilot CLI simultaneously
- **Channel-agnostic** — same agents accessible from Telegram, WebEx, or the web
- **Production-ready** — dev/prod environment separation, systemd services, task scheduling
- **Extensible skills** — plugin architecture for domain-specific capabilities

617 unique cloners in the last 14 days.