### PR TITLE
feat: add agent-wallet-sdk — non-custodial wallet SDK for AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -609,6 +609,18 @@ suggestion, feel free to open an issue or pull request. (Last updated: 2026-03-0
   - A2A protocol compatible
 
 
+
+- [agent-wallet-sdk](https://github.com/up2itnow0822/AgentNexus2) - Non-custodial TypeScript wallet SDK for AI agents. Agents hold their own private keys — no custodial proxy or vendor API dependency.
+
+  681 weekly downloads · TypeScript · MIT
+
+  - x402 payments — auto-pay for HTTP 402 resources
+  - CCTP cross-chain USDC bridge (Circle)
+  - Uniswap V3 + Jupiter token swaps
+  - Per-transaction and daily USD spend limits
+  - EVM (Base, Ethereum, Arbitrum, Polygon) + Solana
+  - AP2 / A2A / MCP compatible
+
 - [Quorum](https://github.com/Detrol/quorum-cli) - Multi-agent AI discussion system for
   structured debates
 


### PR DESCRIPTION
## agent-wallet-sdk

**GitHub:** https://github.com/up2itnow0822/AgentNexus2
**npm:** https://www.npmjs.com/package/elizaos-plugin-agentwallet
**License:** MIT · TypeScript

Non-custodial wallet SDK for AI agents. The agent holds its own private key and signs every transaction locally — no custodial proxy or vendor API dependency.

### Features
- x402 payments (HTTP 402 micropayment protocol)
- CCTP cross-chain USDC bridge via Circle (Base, Ethereum, Arbitrum, Polygon)
- Uniswap V3 + Jupiter token swaps
- Per-transaction and daily USD spend limits
- EVM + Solana support
- AP2, A2A, and MCP compatible (works with Model Context Protocol clients)

### Stats
- 681 weekly npm downloads (21x week-over-week growth as of Mar 2026)
- Deployed live on Base Mainnet