### PR TITLE
Add auto-co: autonomous AI company OS with 14 specialized expert-persona agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -621,3 +621,15 @@ suggestion, feel free to open an issue or pull request. (Last updated: 2026-03-0
   - Auto-discovery of local Ollama models
 
 
+
+
+- [auto-co](https://github.com/NikitaDmitrieff/auto-co-meta) - Autonomous AI company OS
+  with 14 specialized agents that run a startup end-to-end
+
+  0 stars · 0 forks · 1 contributors · 0 issues · Shell · MIT
+
+  - 14 expert-persona agents: CEO (Bezos), CTO (Vogels), Critic (Munger), CFO, marketer, engineer, QA, DevOps, and more
+  - Continuous bash loop — agents debate, decide, and ship real deployments autonomously
+  - Shared markdown consensus file as the cross-cycle relay baton
+  - Human escalation via Telegram for true blockers only
+  - Repo is a live company: built its own landing page, Docker stack, and monitoring across 13 autonomous cycles


### PR DESCRIPTION
## What is auto-co?

**auto-co** is an open-source framework for running a fully autonomous AI company. Unlike other entries which are libraries/tools you build on, auto-co is an opinionated, running company OS — you give it a mission and 14 specialized agents run your startup.

**Why it's a different kind of entry:**
- Not a build-on-top library — it's a complete, running system with a company constitution (CLAUDE.md), decision hierarchy, and cross-cycle state management
- The repo itself was built by an auto-co instance running autonomously across 13 cycles — built its own landing page (live on Railway), Docker stack, business model, and community posts
- Unique Critic agent (Munger persona) that vetoes bad ideas via pre-mortem — prevents the system from chasing shiny objects

**Technical approach:**
- Deliberately boring stack: Bash loop + Claude Code CLI + plain markdown files
- 14 expert-persona agents (Bezos/CEO, Vogels/CTO, Munger/Critic, DHH/engineer, Godin/marketing, etc.)
- No vector stores, no complex RAG — agents reason better with explicit text context
- Convergence rules baked in to prevent planning loops

GitHub: https://github.com/NikitaDmitrieff/auto-co-meta
Landing: https://auto-co-landing-production.up.railway.app