### PR TITLE
Add Xquik X/Twitter data platform for LLM agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -616,4 +616,14 @@ suggestion, feel free to open an issue or pull request. (Last updated: 2026-03-0
   - Terminal UI with real-time streaming
   - Auto-discovery of local Ollama models
 
+- [Xquik](https://github.com/Xquik-dev/x-twitter-scraper) - X/Twitter data platform for
+  LLM agents with MCP server and REST API
+
+  TypeScript · NOASSERTION
+
+  - MCP server with 20 tools for Claude Code, Cursor, Codex, and 40+ agents
+  - 76 REST API endpoints with HMAC webhook delivery
+  - 20 bulk extraction tools for followers, tweets, replies, and more
+  - Real-time account monitoring with WebSocket streaming
+
 


### PR DESCRIPTION
Add [Xquik](https://github.com/Xquik-dev/x-twitter-scraper) to the Frameworks list.

Xquik is an X/Twitter data platform for LLM agents with an MCP server (20 tools), 76 REST API endpoints, HMAC webhooks, and real-time WebSocket streaming. Compatible with Claude Code, Cursor, Codex, and 40+ agents.

Disclosure: I am the developer of Xquik.