### PR TITLE
Add Greywall - deny-by-default sandbox for AI coding agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -629,3 +629,14 @@ suggestion, feel free to open an issue or pull request. (Last updated: 2026-03-0
   - Shared markdown consensus file as the cross-cycle relay baton
   - Human escalation via Telegram for true blockers only
   - Repo is a live company: built its own landing page, Docker stack, and monitoring across 13 autonomous cycles
+
+
+- [Greywall](https://github.com/GreyhavenHQ/greywall) - Deny-by-default sandbox for AI coding agents with filesystem and network isolation
+
+  47 stars · 12 forks · 4 issues · Go · Apache-2.0
+
+  - OS-level sandboxing via bubblewrap/Landlock/seccomp (Linux) and Seatbelt (macOS)
+  - Built-in profiles for agents like Claude Code or OpenCode
+  - Transparent network control via greyproxy with real-time dashboard
+  - Learning mode to trace filesystem access and auto-generate configs
+  - Deny-by-default: restricts to current directory with environment sanitization


### PR DESCRIPTION
Add Greywall to the Frameworks section alongside the security/safety cluster (Agentic Radar, Agent OS, Cordum, etc.).

Greywall is a deny-by-default command sandbox that provides OS-level isolation for AI coding agents. It restricts filesystem access and redirects network traffic, with built-in profiles for agents like Claude Code or OpenCode.