### PR TITLE
Add ORCH — CLI runtime for AI agent team orchestration

### DIFF
--- a/README.md
+++ b/README.md
@@ -624,4 +624,14 @@ suggestion, feel free to open an issue or pull request. (Last updated: 2026-03-1
   - Human escalation via Telegram for true blockers only
   - Repo is a live company: built its own landing page, Docker stack, and monitoring across 13 autonomous cycles
 
+- [ORCH](https://github.com/oxgeneral/ORCH) - CLI runtime for orchestrating AI agent teams from the terminal
 
+  13 stars · 0 forks · 1 contributors · 0 issues · TypeScript · MIT
+
+  - Coordinates Claude Code, OpenCode (Codex/Gemini/Mistral), Cursor, and shell scripts
+  - Formal state machine: todo → in_progress → review → done
+  - Auto-retry on failure with configurable attempts
+  - Inter-agent messaging and shared context store
+  - Goal/team hierarchy for multi-agent coordination
+  - Real-time TUI dashboard (Ink/React)
+  - Available as `@oxgeneral/orch` npm package with programmatic API


### PR DESCRIPTION
## Add ORCH to the Frameworks section

[ORCH](https://github.com/oxgeneral/ORCH) is a CLI runtime that orchestrates teams of AI coding agents with a formal state machine, auto-retry, and inter-agent messaging.

**Why it belongs here:**
- TypeScript-first agent orchestration runtime
- Multi-adapter: Claude Code, OpenCode (Codex/Gemini/Mistral), Cursor, shell
- State machine enforces `todo → in_progress → review → done` lifecycle
- Auto-retry with configurable attempts when agents fail
- Inter-agent pub/sub messaging + shared context store
- Goal/team hierarchy for organizing complex multi-agent workflows
- Real-time TUI dashboard via Ink/React
- Exports full programmatic API as `@oxgeneral/orch` npm package
- 1,647 tests, strict TypeScript, MIT license

**Entry format follows existing conventions in the repository.**