### PR TITLE
Add ConnectOnion framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -625,3 +625,14 @@ suggestion, feel free to open an issue or pull request. (Last updated: 2026-03-1
   - Repo is a live company: built its own landing page, Docker stack, and monitoring across 13 autonomous cycles
 
 
+- [ConnectOnion](https://github.com/openonion/connectonion) - Simple Python framework
+  for production-ready AI agents
+
+  562 stars · 82 forks · 5 contributors · 52 issues · Python · MIT
+
+  - 2-line agent creation with functions as tools
+  - 12 lifecycle hooks and plugin system
+  - Multi-agent networking with trust verification
+  - Built-in tools, approval system, and skills
+
+


### PR DESCRIPTION
Adds ConnectOnion to the Frameworks section — a simple Python framework for building production-ready AI agents with 2-line agent creation, lifecycle hooks, multi-agent networking, and built-in tools.