### PR TITLE
Add Aegis — YAML-based AI agent governance framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -621,3 +621,18 @@ suggestion, feel free to open an issue or pull request. (Last updated: 2026-03-2
   - Repo is a live company: built its own landing page, Docker stack, and monitoring across 13 autonomous cycles
 
 
+- [Aegis](https://github.com/Acacian/aegis) - The simplest way to govern AI agent
+  actions — YAML policy, approval gates, audit logging. Works with LangChain,
+  CrewAI, OpenAI, Anthropic, MCP.
+
+  1 stars · 2 forks · 2 contributors · 4 issues · Python · MIT
+
+  - YAML-based policy engine with pattern matching
+  - Approval gates (auto/human/block) per action type
+  - Cross-framework: LangChain, CrewAI, OpenAI, Anthropic, MCP
+  - Audit logging with JSONL export
+  - Hot-reload, dry-run, policy merge
+  - MCP server for Claude Desktop integration
+  - 531 tests, mypy strict, 92% coverage
+
+


### PR DESCRIPTION
## Summary

- Adds [Aegis](https://github.com/Acacian/aegis) to the Frameworks section
- Aegis is a Python framework for governing AI agent actions via YAML policies, approval gates, and audit logging
- Supports LangChain, CrewAI, OpenAI, Anthropic, and MCP out of the box

## Why it fits this list

Aegis fills a gap in the governance/safety layer for AI agents — rather than building agents, it governs what agents can do. It provides:

- YAML-based policy engine with pattern matching
- Approval gates (auto/human/block) per action type
- Audit logging with JSONL export
- MCP server for Claude Desktop integration
- 531 tests, mypy strict, 92% coverage

MIT licensed, actively maintained, available on PyPI.

## Checklist

- [x] Entry follows the exact format of existing entries (name, description, stats, features)
- [x] Added to the Frameworks section