### PR TITLE
Add claude-recipes: 30+ ready-to-use Claude Code workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -625,3 +625,14 @@ suggestion, feel free to open an issue or pull request. (Last updated: 2026-03-1
   - Repo is a live company: built its own landing page, Docker stack, and monitoring across 13 autonomous cycles
 
 
+- [Claude Recipes](https://github.com/mergisi/claude-recipes) - 100+ ready-to-use Claude
+  Code workflows for SEO, DevOps, analytics, and GitHub automation
+
+  1 stars · 0 forks · 1 contributors · 0 issues · Markdown · MIT
+
+  - Copy-paste recipes with real commands
+  - Covers SEO, DevOps, analytics, GitHub, social media
+  - Built for Claude Code CLI workflows
+  - Production-tested automation patterns
+
+


### PR DESCRIPTION
## Summary

Adds [claude-recipes](https://github.com/mergisi/claude-recipes) to the frameworks list.

**claude-recipes** is a collection of 100+ ready-to-use Claude Code workflows for SEO, DevOps, analytics, GitHub automation, and social media. Each recipe provides copy-paste commands that are production-tested.

- Repo: https://github.com/mergisi/claude-recipes
- License: MIT