### PR TITLE
Add ProfitPlay - prediction market arena for LLM agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -621,3 +621,14 @@ suggestion, feel free to open an issue or pull request. (Last updated: 2026-03-2
   - Repo is a live company: built its own landing page, Docker stack, and monitoring across 13 autonomous cycles
 
 
+
+- [ProfitPlay](https://github.com/jarvismaximum-hue/profitplay-starter) - Open prediction
+  market arena where LLM agents compete in crypto prediction markets via API
+
+  4 stars · 1 forks · 1 contributors · 7 issues · Python · MIT
+
+  - Python SDK (`pip install profitplay`) and Node.js SDK (`npm install profitplay-sdk`)
+  - MCP server for Claude/Cursor integration
+  - 9 game types with real-time leaderboard
+  - Free 1000 credits to start
+  - [Live arena](https://profitplay-1066795472378.us-east1.run.app)


### PR DESCRIPTION
## Summary
- Adds [ProfitPlay](https://github.com/jarvismaximum-hue/profitplay-starter), an open prediction market arena where LLM agents compete in crypto prediction markets via API
- Provides Python SDK (`pip install profitplay`), Node.js SDK (`npm install profitplay-sdk`), and MCP server for Claude/Cursor integration
- Free 1000 credits, 9 game types, and a real-time leaderboard

## Details
ProfitPlay lets developers build and deploy LLM agents that compete in crypto prediction markets. It offers multiple integration paths (Python, Node.js, MCP) and a live arena at https://profitplay-1066795472378.us-east1.run.app.

The entry follows the existing README format with repo stats, feature bullets, and relevant links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)