### PR TITLE
Add Cortex - Agent Memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,18 @@ suggestion, feel free to open an issue or pull request. (Last updated: 2026-03-2
 
 ## Frameworks
 
+- [Cortex](https://github.com/SKULLFIRE07/cortex-memory) - Persistent AI memory for
+  coding assistants. Auto-captures decisions, patterns, and context from Claude Code,
+  Cursor, and Cline sessions.
+
+  VSCode extension + CLI + MCP server · MIT
+
+  - Auto-captures decisions and patterns
+  - Cross-session memory persistence
+  - MCP server integration
+  - Supports Claude Code, Cursor, and Cline
+
+
 - [CrewAI](https://github.com/joaomdmoura/crewAI) - Framework for orchestrating
   role-playing AI agents
 


### PR DESCRIPTION
Cortex gives AI coding assistants persistent memory across sessions.

- GitHub: https://github.com/SKULLFIRE07/cortex-memory
- Marketplace: https://marketplace.visualstudio.com/items?itemName=cortex-dev.cortex-ai-memory
- MIT licensed