### PR TITLE
Add AG2 — community fork of AutoGen (4.3K★, 500K+ monthly PyPI downloads)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,18 @@ suggestion, feel free to open an issue or pull request. (Last updated: 2026-03-2
 
 ## Frameworks
 
+- [AG2](https://github.com/ag2ai/ag2) - Open-source AgentOS for building multi-agent
+  systems, community fork of AutoGen
+
+  4,300 stars · 569 forks · 400+ contributors · 164 issues · Python · Apache-2.0
+
+  - Multi-agent conversation patterns (two-agent, group chat, swarm)
+  - Native LLM support: OpenAI, Anthropic, Gemini, AWS Bedrock, Mistral, Ollama
+  - Built-in MCP (Model Context Protocol) integration
+  - Tool use with @register_for_llm / @register_for_execution decorators
+  - Secure Docker-based code execution
+
+
 - [CrewAI](https://github.com/joaomdmoura/crewAI) - Framework for orchestrating
   role-playing AI agents
 


### PR DESCRIPTION
## Summary
- Add [AG2](https://github.com/ag2ai/ag2) to the Frameworks list in alphabetical position
- AG2 (formerly AutoGen) is a community-maintained fork with its own PyPI package (`ag2`), independent release cycle, and diverging API features (native AWS Bedrock, LLMConfig, Swarm orchestration)
- It is a separate project from Microsoft AutoGen (`microsoft/autogen`) and should be listed independently — 4.3K+ stars, 500K+ monthly PyPI downloads