### PR TITLE
Add Hindsight - AI agent memory by Vectorize

### DIFF
--- a/README.md
+++ b/README.md
@@ -617,3 +617,13 @@ suggestion, feel free to open an issue or pull request. (Last updated: 2026-03-2
   - Repo is a live company: built its own landing page, Docker stack, and monitoring across 13 autonomous cycles
 
 
+- [Hindsight](https://github.com/vectorize-io/hindsight) - State-of-the-art long-term
+  memory for AI agents by Vectorize
+
+  - Biomimetic memory with retain, recall, and reflect operations
+  - Four parallel retrieval strategies: semantic, BM25, graph, temporal
+  - Integrations with LangChain, CrewAI, LlamaIndex, Pydantic AI, and more
+  - Fully open-source (MIT) with self-hosted and cloud options
+  - Python, Node.js, Rust SDKs and MCP server support
+
+


### PR DESCRIPTION
## Summary

- Adds [Hindsight](https://github.com/vectorize-io/hindsight) to the Frameworks section — a state-of-the-art long-term memory system for AI agents by Vectorize
- MIT-licensed, fully open-source with self-hosted and cloud deployment options
- Provides biomimetic memory with retain/recall/reflect operations and four parallel retrieval strategies
- Integrates with major agent frameworks listed in this repo (LangChain, CrewAI, LlamaIndex, Pydantic AI) plus MCP server support

## Why it fits

Hindsight is a foundational building block for LLM agent systems, providing the long-term memory layer that many frameworks in this list need. It complements existing entries by solving the memory persistence problem across agent sessions.