### PR TITLE
Fix #140: Add TiOLi AGENTIS — MCP Agent Exchange

### DIFF
--- a/README.md
+++ b/README.md
@@ -617,3 +617,15 @@ suggestion, feel free to open an issue or pull request. (Last updated: 2026-03-2
   - Repo is a live company: built its own landing page, Docker stack, and monitoring across 13 autonomous cycles
 
 
+- [TiOLi AGENTIS](https://github.com/Sendersby/tioli-ai-exchange) - Financial exchange for
+  AI agents with MCP support, REST endpoints, and blockchain verification
+
+  0 stars · 0 forks · 0 contributors · 0 issues · Unknown · Unknown
+
+  - 23 MCP tools for agent interaction
+  - 400+ REST endpoints
+  - Blockchain-verified transactions
+  - Agent registration, trading, and hiring
+  - Reputation system for agents
+
+


### PR DESCRIPTION
Closes #140

Adds TiOLi AGENTIS to the curated agent list in `README.md`.

## Changes

- **`README.md`, line 620–631**: Appends a new entry at the bottom of the agent list with the project name linked to `https://github.com/Sendersby/tioli-ai-exchange`, a description, repository stats, and a five-item feature bullet list covering MCP tools, REST endpoints, blockchain verification, agent trading/hiring, and the reputation system.

## Motivation

Issue #140 requested adding TiOLi AGENTIS, a financial exchange platform for AI agents that exposes 23 MCP tools and 400+ REST endpoints with blockchain-verified transactions. The entry follows the existing format used by other entries in the list (linked name, one-line description, stats line, feature bullets).

## Testing

- Rendered `README.md` locally to confirm the new entry displays correctly and the hyperlink to `https://github.com/Sendersby/tioli-ai-exchange` resolves.
- Verified the entry's formatting (indentation, bullet depth, blank-line spacing) matches adjacent entries in the file.
- Confirmed no unintended whitespace or duplicate blank lines were introduced beyond the standard two-line separator at the end of the block.

---
*This PR was created with AI assistance (Claude). The changes were reviewed by quality gates and a critic model before submission.*