### PR TITLE
Add Kitaru — durable execution layer for AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -614,3 +614,14 @@ suggestion, feel free to open an issue or pull request. (Last updated: 2026-04-0
   - Repo is a live company: built its own landing page, Docker stack, and monitoring across 13 autonomous cycles
 
 
+- [Kitaru](https://github.com/zenml-io/kitaru) - Durable execution layer for AI agents
+  with checkpoints, replay, resume, and memory
+
+  - Checkpoint-based persistence for agent workflows
+  - Replay and resume from any checkpoint
+  - Wait primitives for human-in-the-loop
+  - Built-in memory management
+  - No graph DSL — write normal Python control flow
+  - PydanticAI adapter for framework integration
+
+


### PR DESCRIPTION
## Summary
- Adds [Kitaru](https://github.com/zenml-io/kitaru) to the Frameworks section
- Kitaru provides durable execution primitives (checkpoints, replay, resume, wait, memory) for AI agent workflows — write normal Python control flow, no graph DSL required
- Includes a PydanticAI adapter for framework integration