### PR TITLE
Add Global Chat - cross-protocol agent discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -614,3 +614,16 @@ suggestion, feel free to open an issue or pull request. (Last updated: 2026-04-0
   - Repo is a live company: built its own landing page, Docker stack, and monitoring across 13 autonomous cycles
 
 
+- [Global Chat](https://github.com/pumanitro/global-chat) - Cross-protocol AI agent
+  discovery platform aggregating agents across MCP, A2A, agents.txt, and 9+ other
+  protocols
+
+  0 stars · 0 forks · 1 contributors · 0 issues · TypeScript
+
+  - Searchable directory of 100,000+ agents across 15+ registries
+  - Protocol-agnostic: MCP, A2A, agents.txt, ACDP, and more
+  - Free agents.txt validator and linter
+  - MCP server for programmatic agent discovery
+  - Open source with npm package (@global-chat/mcp-server)
+
+


### PR DESCRIPTION
Adds [Global Chat](https://github.com/pumanitro/global-chat) to the list.

Global Chat is a discovery layer for AI agents that works across protocols — MCP, A2A, agents.txt, ACDP, and others. It indexes 100K+ agents from 15+ registries into a single searchable directory and ships a free agents.txt validator.

The project also provides an MCP server (`@global-chat/mcp-server` on npm) so other agents can query the directory programmatically.

- Website: https://global-chat.io
- npm: [@global-chat/mcp-server](https://www.npmjs.com/package/@global-chat/mcp-server)