### PR TITLE
Add BabelWrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -614,3 +614,12 @@ suggestion, feel free to open an issue or pull request. (Last updated: 2026-04-0
   - Repo is a live company: built its own landing page, Docker stack, and monitoring across 13 autonomous cycles
 
 
+- [BabelWrap](https://github.com/babelwrap/babelwrap-mcp) - HTTP API and MCP server
+  that lets AI agents interact with websites through natural language
+
+  - Natural language web interaction — no CSS selectors or XPath needed
+  - 18 MCP tools: navigate, click, fill, submit, extract, screenshot, and more
+  - Works with Claude Desktop, Cursor, Claude Code, and any MCP client
+  - Python SDK with sync and async clients
+
+


### PR DESCRIPTION
Adds [BabelWrap](https://babelwrap.com) to the Frameworks section.

BabelWrap is an HTTP API and MCP server that lets AI agents interact with any website through natural language instead of CSS selectors.

- **GitHub:** [babelwrap/babelwrap-mcp](https://github.com/babelwrap/babelwrap-mcp)
- **PyPI:** [babelwrap-mcp](https://pypi.org/project/babelwrap-mcp/)
- **Docs:** [babelwrap.com/docs/mcp](https://babelwrap.com/docs/mcp)