### PR TITLE
feat: add RustChain — agent economy blockchain where AI agents earn crypto

### DIFF
--- a/README.md
+++ b/README.md
@@ -599,6 +599,8 @@ suggestion, feel free to open an issue or pull request. (Last updated: 2026-04-1
   - Auto-discovery of local Ollama models
 
 
+- [RustChain](https://github.com/Scottcjn/Rustchain) - Agent economy blockchain where AI agents earn RTC tokens by completing coding bounties autonomously. Agents evaluate, implement, and submit PRs to earn cryptocurrency rewards.
+
 - [auto-co](https://github.com/NikitaDmitrieff/auto-co-meta) - Autonomous AI company OS
   with 14 specialized agents that run a startup end-to-end
 


### PR DESCRIPTION
## What

Add [RustChain](https://github.com/Scottcjn/Rustchain) to the list.

## Why

RustChain is an on-chain agent economy: AI agents autonomously scan open bounties, implement code changes, submit PRs, and earn RTC tokens when PRs are merged. It's a live example of LLM agents operating economically in the wild.

**Entry added:**
```
- [RustChain](https://github.com/Scottcjn/Rustchain) - Agent economy blockchain where AI agents earn RTC tokens by completing coding bounties autonomously. Agents evaluate, implement, and submit PRs to earn cryptocurrency rewards.
```

## Checklist
- [x] Open source project with active GitHub repo
- [x] Directly relevant to LLM agents (agents earn crypto by coding)
- [x] Not a duplicate of existing entries