### PR TITLE
Add scAgent: natural-language scRNA-seq analysis agent (85.7% SC-Bench)

### DIFF
--- a/README.md
+++ b/README.md
@@ -610,4 +610,15 @@ suggestion, feel free to open an issue or pull request. (Last updated: 2026-04-1
   - Human escalation via Telegram for true blockers only
   - Repo is a live company: built its own landing page, Docker stack, and monitoring across 13 autonomous cycles
 
+- [scAgent](https://github.com/deepmind11/scAgent) - AI agent for single-cell RNA-seq
+  analysis through natural language — no bioinformatics knowledge required
 
+  0 stars · 0 forks · 1 contributors · 0 issues · Python · MIT
+
+  - Full scRNA-seq pipeline in plain English: QC → normalization → batch integration → clustering → cell type annotation → differential expression
+  - Benchmarked at 85.7% on SC-Bench (394 verifiable problems from real workflows), vs 52.8% top baseline
+  - State-aware data inspector: reads AnnData to infer what analysis has already been done before acting
+  - Dependency resolution: plans the minimal prerequisite steps to reach any requested analysis
+  - W3C PROV-O provenance tracking with auto-generated camera-ready methods sections and reproducibility packages
+  - Long-term ChromaDB memory across sessions — recall any decision from weeks ago
+  - Runs on Feynman (open-source runtime) or Claude Code


### PR DESCRIPTION
## Summary

Adds [scAgent](https://github.com/deepmind11/scAgent) — an AI agent for single-cell RNA-seq analysis that lets biologists run a full analysis pipeline through natural language conversation, with no programming knowledge required.

**Why it belongs here:**
- Fully agentic LLM system built on the Feynman runtime (compatible with Claude Code)
- 30+ analysis tools with JSON schemas, dependency resolution, and a paradigm-aware analysis DAG
- Benchmarked at **85.7% on SC-Bench** (394 verifiable problems from real scRNA-seq workflows), vs 52.8% top baseline
- State-aware: inspects loaded AnnData to determine what has already been done before acting
- W3C PROV-O provenance tracking with auto-generated methods sections and reproducibility packages
- Long-term ChromaDB memory across sessions

**Key stats:** Python · MIT · 30+ tools · SC-Bench 85.7%