### PR TITLE
Add Not Human Search — agent-first MCP search engine for LLM tool discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -611,3 +611,13 @@ suggestion, feel free to open an issue or pull request. (Last updated: 2026-04-1
   - Repo is a live company: built its own landing page, Docker stack, and monitoring across 13 autonomous cycles
 
 
+- [Not Human Search](https://nothumansearch.ai) - Agent-first search engine indexing
+  1,100+ tools ranked by agentic readiness
+
+  - MCP server with 6 tools: search_agents, get_site_details, get_stats, submit_site, register_monitor, verify_mcp
+  - Ranks tools by agentic readiness score (API availability, MCP support, documentation quality)
+  - Helps LLM agents discover and evaluate tools programmatically
+  - JSON-RPC endpoint at /mcp for direct agent integration
+  - Real-time MCP verification via live JSON-RPC probe
+
+

--- a/README.md
+++ b/README.md
@@ -611,13 +611,13 @@ suggestion, feel free to open an issue or pull request. (Last updated: 2026-04-1
   - Repo is a live company: built its own landing page, Docker stack, and monitoring across 13 autonomous cycles
 
 
-- [Not Human Search](https://nothumansearch.ai) - Agent-first search engine indexing
-  1,100+ tools ranked by agentic readiness
+- [Not Human Search](https://nothumansearch.ai) - AI-native search engine for MCP
+  servers and AI tools with agentic scoring, REST API, and MCP server
 
+  - 8,600+ AI tools indexed with agentic readiness scoring
   - MCP server with 6 tools: search_agents, get_site_details, get_stats, submit_site, register_monitor, verify_mcp
-  - Ranks tools by agentic readiness score (API availability, MCP support, documentation quality)
-  - Helps LLM agents discover and evaluate tools programmatically
-  - JSON-RPC endpoint at /mcp for direct agent integration
-  - Real-time MCP verification via live JSON-RPC probe
+  - Scores tools by API availability, MCP support, OpenAPI spec, and documentation quality
+  - Live MCP verification via JSON-RPC probe
+  - REST API and MCP endpoint for programmatic agent integration
 
 


### PR DESCRIPTION
## What this adds

[Not Human Search](https://nothumansearch.ai) — an AI-native search engine that indexes 8,600+ AI tools ranked by agentic readiness.

## Why it fits this list

- **Built for LLM agents**: native MCP server at `/mcp` with 6 tools (`search_agents`, `get_site_details`, `get_stats`, `submit_site`, `register_monitor`, `verify_mcp`)
- **Agentic readiness scoring**: ranks tools by API availability, MCP support, OpenAPI spec presence, and documentation quality — so agents can programmatically evaluate which tools are agent-compatible
- **Live MCP verification**: JSON-RPC probe confirms real-time MCP server functionality, not just text mentions
- **REST API + MCP endpoint**: agents can discover and evaluate tools programmatically via either interface
- **8,600+ tools indexed**: comprehensive coverage of the AI tool ecosystem