### PR TITLE
Add grugbot420 to Frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -608,3 +608,13 @@ suggestion, feel free to open an issue or pull request. (Last updated: 2026-04-1
   - Repo is a live company: built its own landing page, Docker stack, and monitoring across 13 autonomous cycles
 
 
+
+- [grugbot420](https://github.com/grug-group420/grugbot420) - Neuromorphic cognitive engine
+  in Julia for multi-model AI orchestration
+
+  6 stars · 0 forks · 1 contributors · 0 issues · Julia · MIT
+
+  - Deploys domain-expert AI specimens through architectural configuration
+  - Multi-model orchestration without traditional training
+  - Neuromorphic cognitive architecture
+  - Configuration-driven agent deployment


### PR DESCRIPTION
## grugbot420

[grugbot420](https://github.com/grug-group420/grugbot420) is a neuromorphic cognitive engine written in Julia for multi-model AI orchestration. It deploys domain-expert AI specimens through architectural configuration rather than traditional training.

- License: MIT
- Language: Julia
- Source: https://github.com/grug-group420/grugbot420