### PR TITLE
Add BenchGecko Agent Leaderboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -606,5 +606,4 @@ suggestion, feel free to open an issue or pull request. (Last updated: 2026-04-1
   - Shared markdown consensus file as the cross-cycle relay baton
   - Human escalation via Telegram for true blockers only
   - Repo is a live company: built its own landing page, Docker stack, and monitoring across 13 autonomous cycles
-
-
+- [BenchGecko Agents](https://benchgecko.ai/agents) - Agent leaderboard tracking 165 AI agents with SWE-bench, GAIA, OSWorld scores and GitHub momentum.


### PR DESCRIPTION
Adds BenchGecko's agent tracking.

https://benchgecko.ai/agents