### PR TITLE
Add langgraph-crosschain to Frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -608,3 +608,15 @@ suggestion, feel free to open an issue or pull request. (Last updated: 2026-04-2
   - Repo is a live company: built its own landing page, Docker stack, and monitoring across 13 autonomous cycles
 
 
+- [langgraph-crosschain](https://github.com/karthyick/langgraph-crosschain) - Cross-chain
+  node communication for LangGraph multi-agent systems
+
+  Python · MIT
+
+  - Direct cross-chain calls: `Chain1.NodeA → Chain2.NodeB`
+  - Shared state management across chains
+  - Message broadcasting to multiple chains
+  - Built specifically as a LangGraph extension for modular multi-agent workflows
+  - `pip install langgraph-crosschain`
+
+


### PR DESCRIPTION
Adding [**langgraph-crosschain**](https://github.com/karthyick/langgraph-crosschain) under **Frameworks**.

A LangGraph extension specifically for **multi-agent and modular workflows** — enables:
- Direct cross-chain node calls: `Chain1.NodeA → Chain2.NodeB`
- Shared state management across chains
- Message broadcasting to multiple chains

Useful when you have agent specializations split across separate LangGraph instances and need them to coordinate without merging into one monolithic graph.

- `pip install langgraph-crosschain`
- MIT license

Thanks for maintaining this list!