### PR TITLE
Add MateClaw — Spring Boot personal AI agent platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -608,3 +608,17 @@ suggestion, feel free to open an issue or pull request. (Last updated: 2026-04-2
   - Repo is a live company: built its own landing page, Docker stack, and monitoring across 13 autonomous cycles
 
 
+- [MateClaw](https://github.com/matevip/mateclaw) - Personal AI operating system on
+  Spring Boot 3.5 + Spring AI Alibaba
+
+  363 stars · 116 forks · 1 contributors · 10 issues · Java · Apache-2.0
+
+  - ReAct + Plan-and-Execute agents on Spring AI Alibaba's StateGraph runtime
+  - Multi-vendor failover chain (DeepSeek, OpenAI, Anthropic, Gemini, DashScope, Kimi, Ollama, LM Studio, MLX) with health tracker and cooldown
+  - LLM Wiki — knowledge digestion into linked pages with per-sentence citations
+  - Memory lifecycle: post-conversation extraction, scheduled consolidation, dreaming workflows
+  - MCP support over stdio, SSE, and Streamable HTTP transports
+  - Tool Guard with RBAC and approval flow for sensitive tool calls
+  - One JAR ships a web admin, desktop app (bundled JRE 21), embeddable widget, and 8 IM channels (DingTalk, Feishu, WeChat Work, WeChat, Telegram, Discord, QQ, Slack)
+
+


### PR DESCRIPTION
## Summary

Adds **MateClaw** — an open-source (Apache 2.0) personal AI agent platform built on Spring Boot 3.5 + Spring AI Alibaba — to the Frameworks list. Appended at the end, following the existing entry format (description + stats line + feature bullets).

## Why it fits

- **Agent runtime**: ReAct + Plan-and-Execute implemented as nodes/edges on Spring AI Alibaba's StateGraph runtime.
- **Multi-vendor LLM routing**: priority chain across DeepSeek, OpenAI, Anthropic, Gemini, DashScope, Kimi, Ollama, LM Studio, MLX with a `ProviderHealthTracker` and cooldown — when one fails, the next picks up mid-stream.
- **Agent infrastructure**: LLM Wiki for knowledge digestion with per-sentence citations, memory lifecycle (extract / consolidate / dream), MCP support over stdio / SSE / Streamable HTTP, and a Tool Guard with RBAC + approval flow.
- **Fills a gap in the list**: this is the first Java/Spring framework entry, complementing the Python and TypeScript-heavy lineup.

## Stats

- 363 stars · 116 forks · 1 contributor · 10 issues · Java · Apache-2.0
- 137 published releases since 2026-04-04, daily commits
- Production deployments: web admin, desktop app (bundled JRE 21), embeddable widget, 8 IM channels

## Links

- Repo: https://github.com/matevip/mateclaw
- Documentation: https://claw.mate.vip/docs
- Live demo: https://claw-demo.mate.vip
- Releases: https://github.com/matevip/mateclaw/releases