### PR TITLE
Add OpenAgent to frameworks list

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,17 @@ suggestion, feel free to open an issue or pull request. (Last updated: 2026-05-0
   - Interactive visualization
 
 
+- [OpenAgent](https://github.com/the-open-agent/openagent) - Personal AI assistant
+  platform with LLM, RAG, and agent workflows
+
+  4,533 stars · 536 forks · 42 issues · Go · Apache-2.0
+
+  - Computer-use, browser-use, and coding agents
+  - Self-hostable with admin dashboard and visual workflow builder
+  - MCP and multi-model provider support
+  - Demo at demo.openagentai.org
+
+
 - [AI Legion](https://github.com/eumemic/ai-legion) - Swarm framework for autonomous
   agents
 


### PR DESCRIPTION
## What is OpenAgent?

**OpenAgent** ([GitHub](https://github.com/the-open-agent/openagent)) is an Apache-2.0 Go project for a self-hosted personal assistant: LLM + RAG, agent loops, and tooling aimed at coding, browser automation, and related desktop-side tasks. MCP is supported for wiring external tools and providers.

**Pointers**

- Demo: https://demo.openagentai.org  
- Site: https://www.openagentai.org  
- License: Apache-2.0  

Listed with other framework-scale assistant / orchestration entries in this repo.