### PR TITLE
Add OpenLeash

### DIFF
--- a/README.md
+++ b/README.md
@@ -606,3 +606,13 @@ suggestion, feel free to open an issue or pull request. (Last updated: 2026-05-0
   - Repo is a live company: built its own landing page, Docker stack, and monitoring across 13 autonomous cycles
 
 
+- [OpenLeash](https://github.com/openleash/openleash) - Local-first authorization sidecar
+  for AI agents with YAML policies and cryptographic proof tokens
+
+  13 stars · 3 forks · 4 contributors · 1 issues · TypeScript · Apache-2.0
+
+  - YAML policy engine returning ALLOW / DENY / REQUIRE_APPROVAL / REQUIRE_STEP_UP / REQUIRE_DEPOSIT decisions
+  - PASETO v4.public proof tokens (Ed25519-signed) verifiable offline by any counterparty
+  - Human-in-the-loop approval workflow with append-only audit log
+  - SDKs at full endpoint parity for TypeScript, Python, and Go
+  - Built-in policy playground for testing scenarios before deploying


### PR DESCRIPTION
Adds [OpenLeash](https://github.com/openleash/openleash) to the Frameworks section.

OpenLeash is a local-first authorization sidecar for AI agents. Before an agent takes a side-effectful action — purchase, booking, API call, message — it asks OpenLeash, which evaluates YAML policies and returns one of `ALLOW` / `DENY` / `REQUIRE_APPROVAL` / `REQUIRE_STEP_UP` / `REQUIRE_DEPOSIT`. Approved actions get a short-lived PASETO v4.public proof token (Ed25519-signed) that any counterparty can verify offline.

It sits naturally alongside existing entries like Agent OS, AgentMesh, and Cordum — agent infrastructure focused on policy enforcement, governance, and audit, rather than on agent reasoning.

Project facts:

- Apache-2.0, current release v0.20.5, regular cadence
- Three SDKs at endpoint parity (TypeScript, Python, Go)
- CI on every push, Docker images at \`ghcr.io/openleash/openleash\`

Followed the existing entry format: title + dash + description, blank line, stats line, blank line, 4–6 feature bullets, double blank line. Happy to adjust if anything looks off.