### PR TITLE
Add Thalamus — cognitive routing layer for multi-agent AI on edge devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -606,3 +606,16 @@ suggestion, feel free to open an issue or pull request. (Last updated: 2026-05-0
   - Repo is a live company: built its own landing page, Docker stack, and monitoring across 13 autonomous cycles
 
 
+- [Thalamus](https://github.com/msbel5/openclaw-thalamus) - Cognitive routing layer
+  for multi-agent AI crews on edge devices (Raspberry Pi 5)
+
+  0 stars · 0 forks · 1 contributors · 0 issues · JavaScript · MIT
+
+  - 3-field packet handoff `{packet_id, resolver_key, inline_vector}` replaces transcript paste between agents
+  - 5-agent crew: Captain, Builder, Inspector, Liaison, Archivist (NASA Mission Control style)
+  - 9-namespace local vector store with Qwen3-Embedding-0.6B Q4_0 GGUF (1024d) on CPU via llama.cpp
+  - Optional Hailo-10H NPU HEFs for Whisper ASR + CLIP vision
+  - FAISS RaBitQ (BBQ) concept-codes lane (raw measurement output in [BENCHMARKS.md](https://github.com/msbel5/openclaw-thalamus/blob/main/BENCHMARKS.md))
+  - MCP server, dashboard with HMAC bearer auth, npm-installable as `openclaw-thalamus`
+
+


### PR DESCRIPTION
Adds [Thalamus](https://github.com/msbel5/openclaw-thalamus) under Frameworks.

Built for the Raspberry Pi 5 + optional Hailo-10H NPU. Replaces transcript paste between agents with a 3-field `{packet_id, resolver_key, inline_vector}` handoff. Receiver resolves only the relevant atoms from a 9-namespace local vector store. Encoder daemon runs Qwen3-Embedding-0.6B Q4_0 GGUF (1024d) on CPU via llama.cpp, with optional Hailo HEFs for Whisper ASR and CLIP vision.

MCP server tools, HTTP dashboard with HMAC bearer auth, FAISS RaBitQ codebook for concept compression, and Inspector → GitHub PR comment integration. Brand new — 0 stars, 1 contributor — but production-shipped on a real Pi 5 with raw measurement output paste-in verbatim in [BENCHMARKS.md](https://github.com/msbel5/openclaw-thalamus/blob/main/BENCHMARKS.md). MIT licensed, npm package `openclaw-thalamus`.

Counts in the entry are honest current numbers (0 stars). Happy to revise if maintainers prefer.