### PR TITLE
Add OpenHermit to Frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -606,3 +606,15 @@ suggestion, feel free to open an issue or pull request. (Last updated: 2026-05-0
   - Repo is a live company: built its own landing page, Docker stack, and monitoring across 13 autonomous cycles
 
 
+
+
+- [OpenHermit](https://github.com/HCF-S/openhermit) - Open-source platform for deploying
+  AI agents as production services with fleet ops
+
+  24 stars · 2 forks · 1 contributors · 0 issues · TypeScript · MIT
+
+  - Internal state (memory, sessions, skills, MCP, schedules, secrets) in Postgres, scoped by agent_id
+  - Per-agent Docker workspaces for isolated execution
+  - Fleet ops via single commands (`hermit skills enable my-skill --all`)
+  - CLI, Web admin UI, and Telegram/Discord/Slack channels
+  - Audit any agent's session from one admin UI


### PR DESCRIPTION
Adds [OpenHermit](https://github.com/HCF-S/openhermit) under **Frameworks**.

**What it is:** Open-source platform for deploying AI agents as production services. The core design choice: internal state (memory, sessions, skills, MCP, schedules, secrets) lives in Postgres scoped by `agent_id`, while per-agent Docker workspaces hold the external file state. Once internal state is centralized, fleet ops become a single command — `hermit skills enable my-skill --all` pushes a skill to 100 agents; any session is auditable from one admin UI.

**Why it fits the list:** general-purpose LLM agent framework, MIT, TypeScript, actively developed.

- Repo: https://github.com/HCF-S/openhermit
- License: MIT
- Language: TypeScript

Followed the existing entry format (link + one-line summary, stats line, feature bullets). Happy to adjust formatting or section placement if needed.