### PR TITLE
Add json-correction-loop framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -606,3 +606,14 @@ suggestion, feel free to open an issue or pull request. (Last updated: 2026-05-0
   - Repo is a live company: built its own landing page, Docker stack, and monitoring across 13 autonomous cycles
 
 
+- [json-correction-loop](https://github.com/warpspaceinc/json-correction-loop) - Critic-driven correction loop for large LLM-generated JSON state
+
+  0 stars · Python · Apache-2.0
+
+  - Domain-neutral `gather → plan → execute` loop with surgical RFC 6902 patching — bring your own critic / patcher prompt
+  - Sub-agent decomposition: `path_finder` redirects critic-flagged symptom pointers to root-cause pointers; context narrowing scopes both sub-agent and patcher to the affected slice
+  - Composable convergence policies (quality-stable, hardcap) and `StorageBackend` / `EventSink` Protocols
+  - Empirical: at 100-entity / 183-edge synthetic KG with 8 mixed defects (gpt-4o-mini), full-regen fixes 0/8 in 73K tokens; this stack fixes 8/8 in 17K tokens
+  - Provider-agnostic — works with OpenAI, Anthropic, OpenRouter
+
+


### PR DESCRIPTION
Adding [json-correction-loop](https://github.com/warpspaceinc/json-correction-loop) — a domain-neutral critic→plan→execute loop framework for large LLM-generated JSON state.

Why it might fit this list:

- **Framework, not application.** Brings your own critic and (optionally) LLM patcher; the library provides the loop driver, planners, sub-agents (path_finder, request_validator, patch_evaluator, template_filler), and convergence policies.
- **Provider-agnostic.** Works with OpenAI, Anthropic, OpenRouter via Protocols (`StorageBackend`, `EventSink`, `LLMClient`).
- **Concrete value prop measured.** At 100-entity / 183-edge synthetic KG with 8 mixed defects on gpt-4o-mini, full-regen fixes 0/8 in 73K tokens / 8.5 min; this stack fixes 8/8 in 17K tokens / 26s. Numbers + ablation in `EXPERIMENTS.md`.
- Apache-2.0, on PyPI (`pip install json-correction-loop`), Python 3.11+.

I'm a contributor; happy to revise placement / wording.