### PR TITLE
Add Bernstein - deterministic orchestrator for CLI coding agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -604,3 +604,17 @@ suggestion, feel free to open an issue or pull request. (Last updated: 2026-05-1
   - Repo is a live company: built its own landing page, Docker stack, and monitoring across 13 autonomous cycles
 
 
+- [Bernstein](https://github.com/sipyourdrink-ltd/bernstein) - Python orchestrator for
+  40+ CLI coding agents (Claude Code, Codex, Gemini CLI, Cursor, Aider) with
+  deterministic scheduling
+
+  350 stars · Python · Apache-2.0
+
+  - One LLM plan call up front; scheduling, isolation, and merge are deterministic Python
+  - Git worktree per task — parallel agents never collide
+  - Quality gates run tests/lints before any merge into main
+  - HMAC-chained audit log of every step, replayable bit-for-bit
+  - MCP server mode and A2A protocol support
+  - On PyPI as `bernstein`
+
+

--- a/README.md
+++ b/README.md
@@ -597,12 +597,12 @@ suggestion, feel free to open an issue or pull request. (Last updated: 2026-07-1
   40+ CLI coding agents (Claude Code, Codex, Gemini CLI, Cursor, Aider) with
   deterministic scheduling
 
-  350 stars · Python · Apache-2.0
+  737 stars · 75 forks · Python · Apache-2.0
 
   - One LLM plan call up front; scheduling, isolation, and merge are deterministic Python
-  - Git worktree per task — parallel agents never collide
+  - Git worktree per task, so parallel agents never collide
   - Quality gates run tests/lints before any merge into main
-  - HMAC-chained audit log of every step, replayable bit-for-bit
+  - Opt-in HMAC-chained audit log of every step, verifiable offline
   - MCP server mode and A2A protocol support
   - On PyPI as `bernstein`
 


### PR DESCRIPTION
Adds Bernstein under Frameworks, at the bottom of the list.

- Repo: https://github.com/sipyourdrink-ltd/bernstein
- License: Apache-2.0
- 350 stars, on PyPI as `bernstein`.
- Python orchestrator for 40+ CLI coding agents (Claude Code, Codex, Gemini CLI, Cursor, Aider, OpenCode, and more). One LLM plan call up front; after that, scheduling, git worktree isolation per task, quality gates, and an HMAC-chained audit log of every step are deterministic Python.
- Complements existing entries (CrewAI, AutoGen, AgentField, Cordum) by focusing on coordinating CLI coding agents rather than wrapping API LLMs.

Maintainer disclosure: I am the maintainer.