### PR TITLE
Add Septim Agents Pack

### DIFF
--- a/README.md
+++ b/README.md
@@ -593,6 +593,7 @@ suggestion, feel free to open an issue or pull request. (Last updated: 2026-05-1
 
 
 - [auto-co](https://github.com/NikitaDmitrieff/auto-co-meta) - Autonomous AI company OS
+- [Septim Agents Pack](https://septimlabs.com/agents) - 10 named Claude Code sub-agents (Atlas, Luca, Canon, Ember, Tally, Nova, Ward, Mira, Juno, Pip) for solo founders. Pip is open-sourced under MIT at github.com/septimlabs-code/septim-agents-pack-sample.
   with 14 specialized agents that run a startup end-to-end
 
   34 stars · 7 forks · 1 contributors · 4 issues · TypeScript · MIT


### PR DESCRIPTION
Adds the [Septim Agents Pack](https://septimlabs.com/agents) — 10 named Claude Code sub-agents covering the full exec layer for solo founders (chief of staff, CTO, brand, CMO, CFO, design, legal, customer, research, intern coordinator).

The pack ships under the Claude Code sub-agent framework: each agent is a markdown file dropped into `~/.claude/agents/`, invoked via `/agents <name>`.

One agent (Pip the intern) is open-sourced under MIT at https://github.com/septimlabs-code/septim-agents-pack-sample so anyone can evaluate the format before buying the full pack.

Thanks for maintaining this list.
