### PR TITLE
Add Alfred

### DIFF
--- a/README.md
+++ b/README.md
@@ -604,11 +604,12 @@ suggestion, feel free to open an issue or pull request. (Last updated: 2026-05-1
   - Repo is a live company: built its own landing page, Docker stack, and monitoring across 13 autonomous cycles
 
 
-- [Alfred](https://github.com/luminik-io/alfred-os) - Local runtime that turns GitHub issues and specs into autonomous Claude Code and Codex runs
+- [Alfred](https://github.com/luminik-io/alfred-os) - Self-hosted runtime for autonomous
+  Claude Code and Codex agents that turn GitHub issues into pull requests
 
-  1 star · Python · MIT
+  1 star · 0 forks · 0 contributors · 0 issues · Python · MIT
 
-  - GitHub issues become scheduled, bounded coding-agent jobs
-  - Isolated git worktrees per run
-  - Label-based state, review/test routing, and Slack reports
-  - autonomous scheduled runs that survive host restarts on macOS and Linux
+  - GitHub issues and specs become scheduled, bounded coding-agent jobs
+  - Each firing runs in a clean git worktree, so failures cannot pollute other work
+  - Label-driven state machine (agent:in-flight, agent:pr-open, agent:done) plus role-based engine routing across Claude Code and Codex
+  - Scheduled runs survive host restarts (macOS launchd, Linux systemd) with Slack-only reporting

--- a/README.md
+++ b/README.md
@@ -604,7 +604,7 @@ suggestion, feel free to open an issue or pull request. (Last updated: 2026-05-1
   - Repo is a live company: built its own landing page, Docker stack, and monitoring across 13 autonomous cycles
 
 
-- [Alfred](https://github.com/luminik-io/alfred-os) - Local runtime for autonomous repo teammates on Claude Code and Codex
+- [Alfred](https://github.com/luminik-io/alfred-os) - Local runtime that turns GitHub issues and specs into autonomous Claude Code and Codex runs
 
   1 star · Python · MIT
 

--- a/README.md
+++ b/README.md
@@ -459,7 +459,18 @@ suggestion, feel free to open an issue or pull request. (Last updated: 2026-05-1
   - Agents view terminal screens, subscribe to activity, spawn/fork/resume each other
   - TUI dashboard, cross-device relay via MQTT, Python API
   - Multi-agent workflow scripts: debates, ensemble refinement, code review watchers
-  - Just prefix `hcom` in front of your existing tool command- [everyrow](https://github.com/futuresearch/everyrow-sdk) - AI-powered data operations
+  - Just prefix `hcom` in front of your existing tool command
+
+- [Alfred](https://github.com/luminik-io/alfred-os) - Local engineering-agent fleet runtime for Claude Code and Codex
+
+  1 star · Python · MIT
+
+  - GitHub issues become scheduled, bounded coding-agent jobs
+  - Isolated git worktrees per run
+  - Label-based state, review/test routing, and Slack reports
+  - launchd and systemd scheduling for local machines
+
+- [everyrow](https://github.com/futuresearch/everyrow-sdk) - AI-powered data operations
   SDK for running LLM agents on pandas DataFrames
 
   34 stars · 4 forks · 12 contributors · 3 issues · Python · MIT
@@ -600,5 +611,4 @@ suggestion, feel free to open an issue or pull request. (Last updated: 2026-05-1
   - Shared markdown consensus file as the cross-cycle relay baton
   - Human escalation via Telegram for true blockers only
   - Repo is a live company: built its own landing page, Docker stack, and monitoring across 13 autonomous cycles
-
 

--- a/README.md
+++ b/README.md
@@ -604,11 +604,11 @@ suggestion, feel free to open an issue or pull request. (Last updated: 2026-05-1
   - Repo is a live company: built its own landing page, Docker stack, and monitoring across 13 autonomous cycles
 
 
-- [Alfred](https://github.com/luminik-io/alfred-os) - Local engineering-agent fleet runtime for Claude Code and Codex
+- [Alfred](https://github.com/luminik-io/alfred-os) - Local runtime for autonomous repo teammates on Claude Code and Codex
 
   1 star · Python · MIT
 
   - GitHub issues become scheduled, bounded coding-agent jobs
   - Isolated git worktrees per run
   - Label-based state, review/test routing, and Slack reports
-  - launchd and systemd scheduling for local machines
+  - autonomous scheduled runs that survive host restarts on macOS and Linux

--- a/README.md
+++ b/README.md
@@ -461,15 +461,6 @@ suggestion, feel free to open an issue or pull request. (Last updated: 2026-05-1
   - Multi-agent workflow scripts: debates, ensemble refinement, code review watchers
   - Just prefix `hcom` in front of your existing tool command
 
-- [Alfred](https://github.com/luminik-io/alfred-os) - Local engineering-agent fleet runtime for Claude Code and Codex
-
-  1 star · Python · MIT
-
-  - GitHub issues become scheduled, bounded coding-agent jobs
-  - Isolated git worktrees per run
-  - Label-based state, review/test routing, and Slack reports
-  - launchd and systemd scheduling for local machines
-
 - [everyrow](https://github.com/futuresearch/everyrow-sdk) - AI-powered data operations
   SDK for running LLM agents on pandas DataFrames
 
@@ -612,3 +603,12 @@ suggestion, feel free to open an issue or pull request. (Last updated: 2026-05-1
   - Human escalation via Telegram for true blockers only
   - Repo is a live company: built its own landing page, Docker stack, and monitoring across 13 autonomous cycles
 
+
+- [Alfred](https://github.com/luminik-io/alfred-os) - Local engineering-agent fleet runtime for Claude Code and Codex
+
+  1 star · Python · MIT
+
+  - GitHub issues become scheduled, bounded coding-agent jobs
+  - Isolated git worktrees per run
+  - Label-based state, review/test routing, and Slack reports
+  - launchd and systemd scheduling for local machines


### PR DESCRIPTION
Adds Alfred as a local engineering-agent fleet runtime for Claude Code and Codex. It fits this list as an LLM agent runtime/orchestration tool: GitHub issues become scheduled, bounded coding-agent jobs with isolated worktrees, label state, review/test routing, and Slack reports.

Source: https://github.com/luminik-io/alfred-os

Validation: git diff --check