### PR TITLE
Add Perseus — context engine + multi-agent coordination substrate

### DIFF
--- a/README.md
+++ b/README.md
@@ -592,3 +592,11 @@ suggestion, feel free to open an issue or pull request. (Last updated: 2026-07-2
   - Repo is a live company: built its own landing page, Docker stack, and monitoring across 13 autonomous cycles
 
 
+- [Perseus](https://github.com/Perseus-Computing-LLC/perseus) - Local-first live context
+  engine and MCP server for AI coding agents
+
+  - Compile-before-context: pre-resolves git, services, tests, and memory into a ready context briefing at session start
+  - Multi-agent coordination — shared task boards and point-to-point agent messaging
+  - MCP server façade exposing Perseus tools to any MCP client
+  - Assistant-agnostic — works with Claude Code, Cursor, Codex, and other MCP clients
+  - MIT, Python, published on PyPI as perseus-ctx


### PR DESCRIPTION
Adds Perseus to the Frameworks list.

Perseus is two things in one binary:

1. **A live context engine** — resolves directives like `@query "git status"`, `@services`, and `@waypoint` into the markdown file the assistant reads at session start (`CLAUDE.md`, `AGENTS.md`, `.cursorrules`, `.hermes.md`). Compile-before-context as an alternative to runtime MCP tool calls.

2. **A coordination substrate for agent swarms** — atomic filesystem-locked checkpoints (`O_CREAT | O_EXCL`), `@agora` shared task boards, `@inbox` point-to-point messaging. Tested with 120-agent swarms (150 concurrent writers, zero collisions on local NVMe).

Borderline-fit-wise: Perseus isn't a traditional framework like CrewAI or AutoGen — it's the layer underneath. I think it earns a slot here because (a) it's specifically designed for multi-agent coordination at scale, and (b) several entries already on this list (`hcom`, `Agent Protocol`, `OpenAgents`) are similarly infrastructure rather than frameworks. Happy to refile under a "Coordination & Infrastructure" subsection if you'd prefer.

- Repo: https://github.com/tcconnally/perseus
- PyPI: `pip install perseus-ctx`
- Site: https://perseus.observer
- 596 tests, MIT, Python 3.10+, single-file or modular
- Listed on the MCP Registry; Anthropic Skills marketplace PR open ([anthropics/skills#1193](https://github.com/anthropics/skills/pull/1193))