### PR TITLE
Add TWZRD Agent Intel — trust-scoring MCP server for x402 agents on Solana

### DIFF
--- a/README.md
+++ b/README.md
@@ -576,6 +576,16 @@ suggestion, feel free to open an issue or pull request. (Last updated: 2026-05-3
   - A2A protocol compatible
 
 
+- [TWZRD Agent Intel](https://intel.twzrd.xyz) - Trust-scoring MCP server for x402 agents on Solana — free preflight check + signed V5 trust receipt via USDC micropayment
+
+  MCP endpoint: https://intel.twzrd.xyz/mcp · Solana · MIT
+
+  - Agent trust scoring via `resolve_agent`, `score_agent`, `get_trust_receipt`, `verify_trust_receipt`
+  - On-chain trust receipts settled via USDC micropayment (<1s) on Solana
+  - x402 payment protocol support for agent-to-agent micropayments
+  - Registered at registry.modelcontextprotocol.io
+
+
 - [Quorum](https://github.com/Detrol/quorum-cli) - Multi-agent AI discussion system for
   structured debates
 


### PR DESCRIPTION
## Summary

Adds **TWZRD Agent Intel** to the Frameworks section, alongside other agent trust/identity tools (AgentOS, AgentMesh).

TWZRD Agent Intel is a trust-scoring MCP server for autonomous agents operating on Solana via the x402 payment protocol:

- **Free preflight check** via `resolve_agent` / `score_agent` — check an agent's on-chain trust score before interacting
- **Signed V5 trust receipt** via `get_trust_receipt` — paid endpoint (<1s USDC settlement on Solana) returning a cryptographically signed trust receipt
- **MCP endpoint**: `https://intel.twzrd.xyz/mcp` (Streamable-HTTP, registered at `registry.modelcontextprotocol.io`)
- Tools: `resolve_agent`, `score_agent`, `get_trust_receipt`, `verify_trust_receipt`

Fits alongside AgentMesh and AgentOS as part of the growing agent trust/identity infrastructure layer.

**Links**: [Website](https://intel.twzrd.xyz) · [GitHub](https://github.com/twzrd-sol/wzrd-final) · [MCP Registry](https://registry.modelcontextprotocol.io)