### PR TITLE
Add ABVX Agent Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -571,6 +571,40 @@ suggestion, feel free to open an issue or pull request. (Last updated: 2026-06-0
   - Includes reusable HTML artifact skills for diagrams, briefs, and explainers
 
 
+- [AGENTS.md Generator](https://github.com/markoblogo/AGENTS.md_generator) - Safe
+  repo-docs generator for AI coding agents with marker-based updates and diff-first
+  workflows
+
+  4 stars · 0 forks · 1 contributors · 0 issues · Python · MIT
+
+  - Generates and updates `AGENTS.md` and `RUNBOOK.md` without overwriting hand-written docs
+  - Emits machine-readable repo context for CI, MCP, and pack workflows
+  - Conservative auto-detect and fail-safe `*.generated.md` fallback model
+  - Built for repeatable agent setup across repositories
+
+
+- [ID](https://github.com/markoblogo/ID) - Portable protocol for structured human-AI
+  interaction context with explicit freshness, trust, and privacy rules
+
+  0 stars · 0 forks · 1 contributors · 0 issues · Python · MIT
+
+  - Externalizes user profile and context instead of hiding it in tool-local memory
+  - Defines auditable contracts for freshness, privacy, and cross-tool portability
+  - Designed to complement orchestrators and repo-doc systems
+  - Ships validation and compact artifact generation for portable context handoff
+
+
+- [SET](https://github.com/markoblogo/SET) - Thin orchestration layer for agent-facing
+  repo workflows in CI
+
+  0 stars · 0 forks · 1 contributors · 0 issues · Python · MIT
+
+  - Orchestrates repo-doc, proof-loop, and registry-driven workflows
+  - Keeps AI-facing repository artifacts in sync through explicit presets
+  - Bridges repo config, optional ID hooks, and public catalog surfaces
+  - Designed as a control plane rather than another assistant runtime
+
+
 - [Agent OS](https://github.com/imran-siddique/agent-os) - Safety-first kernel for
   governing autonomous AI agents with POSIX-inspired primitives
 
@@ -615,4 +649,3 @@ suggestion, feel free to open an issue or pull request. (Last updated: 2026-06-0
   - Shared markdown consensus file as the cross-cycle relay baton
   - Human escalation via Telegram for true blockers only
   - Repo is a live company: built its own landing page, Docker stack, and monitoring across 13 autonomous cycles
-

--- a/README.md
+++ b/README.md
@@ -556,7 +556,22 @@ suggestion, feel free to open an issue or pull request. (Last updated: 2026-06-0
   - Flexible evaluation via heuristic metrics and LLM-as-a-judge
   - Works with any LLM provider through LiteLLM
   - Clean abstraction layer for custom optimizers and evaluators
-  - Built-in logging, progress tracking, and reproducible experimentation- [Agent OS](https://github.com/imran-siddique/agent-os) - Safety-first kernel for
+  - Built-in logging, progress tracking, and reproducible experimentation
+
+
+- [ABVX Agent Skills](https://github.com/markoblogo/abvx-agent-skills) - Portable,
+  validation-gated agent skills and Codex workflows packaged as reusable `SKILL.md`
+  skillpacks
+
+  2 stars · 0 forks · 1 contributors · 2 issues · Python · MIT
+
+  - Reviewable skillpacks with explicit triggers, risk notes, and attribution
+  - CLI for listing, installing, validating, and security-auditing skills
+  - Designed for progressive disclosure instead of always-loaded prompt bloat
+  - Includes reusable HTML artifact skills for diagrams, briefs, and explainers
+
+
+- [Agent OS](https://github.com/imran-siddique/agent-os) - Safety-first kernel for
   governing autonomous AI agents with POSIX-inspired primitives
 
   68 stars · 20 forks · 14 contributors · 0 issues · Python · MIT
@@ -564,7 +579,10 @@ suggestion, feel free to open an issue or pull request. (Last updated: 2026-06-0
   - Policy engine with violation guarantees
   - Resource quotas and audit logging
   - Integrations with CrewAI, LangChain, AutoGen, Semantic Kernel
-  - MCP server support- [AgentMesh](https://github.com/imran-siddique/agent-mesh) - Secure trust layer for
+  - MCP server support
+
+
+- [AgentMesh](https://github.com/imran-siddique/agent-mesh) - Secure trust layer for
   multi-agent ecosystems with zero-trust governance
 
   18 stars · 6 forks · 4 contributors · 0 issues · Python · MIT
@@ -597,5 +615,4 @@ suggestion, feel free to open an issue or pull request. (Last updated: 2026-06-0
   - Shared markdown consensus file as the cross-cycle relay baton
   - Human escalation via Telegram for true blockers only
   - Repo is a live company: built its own landing page, Docker stack, and monitoring across 13 autonomous cycles
-
 


### PR DESCRIPTION
## Summary
- add ABVX Agent Skills as a reusable skillpack / agent development tool
- add AGENTS.md Generator as repo-doc tooling for AI coding agents
- add ID as a portable structured human-AI context protocol
- add SET as a thin orchestration layer for agent-facing repo workflows
- fix two adjacent markdown list joins around nearby entries so the section renders cleanly

## Why these fit
These projects are all directly about agent tooling, agent context, agent workflow orchestration, or reusable agent capabilities.

I did not include unrelated ABVX repositories that are not agent-framework/tooling entries in the spirit of this list.

## LLM disclosure
I used Codex as an editing assistant and reviewed the final diff before submitting.
