### PR TITLE
Add OpenAcme — local-first AI workforce platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -598,3 +598,15 @@ suggestion, feel free to open an issue or pull request. (Last updated: 2026-06-1
   - Repo is a live company: built its own landing page, Docker stack, and monitoring across 13 autonomous cycles
 
 
+- [OpenAcme](https://github.com/sandydasari/openacme) - Local-first AI workforce platform
+  where named agents self-organize through task delegation
+
+  TypeScript · MIT
+
+  - Each agent carries a role, persona, tools, memory, and its own MCP servers
+  - Agents assign tasks to each other via a shared board; scheduler wakes coworkers when dependencies clear
+  - BYO model: Anthropic, OpenAI, Google, OpenRouter, Ollama — or use Claude Pro / ChatGPT Plus subscription
+  - Per-agent browser sessions, per-agent SQLite-backed conversation history
+  - Local-first: sessions, tasks, memories, and OAuth tokens stay on your machine; no telemetry
+
+


### PR DESCRIPTION
## What

Adds [OpenAcme](https://github.com/sandydasari/openacme) to the Frameworks section.

## Why

OpenAcme is a local-first AI workforce platform written in TypeScript (MIT). It fits here alongside CrewAI, AutoGen, and Mastra as a multi-agent orchestration framework — but with a distinctive angle: it's a *workforce* runtime, not a library. Each agent carries a role, persona, tools, memory, and its own MCP servers. Agents assign tasks to each other via a shared board; the scheduler wakes coworkers when dependencies clear.

Key differentiators:
- **Local-first**: sessions, tasks, memories, OAuth tokens stay on your machine — no telemetry
- **BYO model**: Anthropic, OpenAI, Google, OpenRouter, Ollama, or sign in with Claude Pro / ChatGPT Plus
- **MCP client**: each agent connects to its own configured MCP servers
- **TypeScript**, MIT license, installable via `npm install -g @openacme/cli`