### PR TITLE
Add inite-brain-service

### DIFF
--- a/README.md
+++ b/README.md
@@ -597,3 +597,4 @@ suggestion, feel free to open an issue or pull request. (Last updated: 2026-06-2
   - Repo is a live company: built its own landing page, Docker stack, and monitoring across 13 autonomous cycles
 
 
+- [Inite Brain](https://github.com/inite-ai/inite-brain-service) - Open-source memory layer (bitemporal knowledge graph) for LLM agents. MCP server over Streamable HTTP, 18 tools across read/write/admin scopes. AGPL-3.0.


### PR DESCRIPTION
Adds inite-brain-service — open-source (AGPL-3.0) bitemporal memory layer for LLM agents. MCP server (Streamable HTTP) exposing 18 tools across read/write/admin scopes.

Distinct from existing memory entries: bitemporal (valid-time + transaction-time both modelled), conflict resolver with supersede/competing/revive semantics, three memory tiers (facts/episodes/procedural), GDPR-grade forget_entity. LoCoMo-benchmarked.

Repo: https://github.com/inite-ai/inite-brain-service
MCP Registry entry: io.github.inite-ai/inite-brain-service (in flight)