### PR TITLE
Add Marketing & SEO category

### DIFF
--- a/README.md
+++ b/README.md
@@ -597,3 +597,6 @@ suggestion, feel free to open an issue or pull request. (Last updated: 2026-06-2
   - Repo is a live company: built its own landing page, Docker stack, and monitoring across 13 autonomous cycles
 
 
+## Marketing & SEO
+
+- [awesome-aeo-seo-agents](https://github.com/discoveredlabs/awesome-aeo-seo-agents) - Curated list of agentic GEO/AEO frameworks, MCP servers for SEO data, agent skill packages, and autonomous content optimisation pipelines for AI search.


### PR DESCRIPTION
Hey - adding a Marketing & SEO category. It's a pretty clear gap given how much commercial work is being done with LLM agents in this space.

awesome-aeo-seo-agents covers agentic GEO/AEO frameworks, MCP servers for SEO data, agent skill packages, and autonomous content optimisation pipelines.

All maintained by myself at Discovered.

**Alternatively, if individual links fit better, these are the most relevant from our work:**

- [Agentic Browsing Checker](https://discoveredlabs.com/tools/agentic-browsing-checker) - free tool running 19 OPERABLE framework checks on any URL (WebMCP registration, form annotation, accessibility tree, llms.txt, ARIA live regions, AI crawler robots.txt access); tells you whether a site is compatible with LLM agents before you build against it
- [AI Assist Widget](https://discoveredlabs.com/tools/ai-assist-widget) - single script tag adding a button bar that opens ChatGPT, Claude, Perplexity, Grok, or Gemini with the current page pre-filled; useful reference for teams thinking about browser-side agent integration patterns
- [How Gemini Works: AI Agent Architecture Deep Dive](https://discoveredlabs.com/blog/how-gemini-works-ai-agent-architecture-deepdive) - protocol-level analysis of Gemini's agent session architecture: 227 RPC calls across 28 methods, 138 feature flags, 6 routing modes including Agent and Deep Research modes