### PR TITLE
Add IronClaw (security-hardened agent runtime) to Frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -595,4 +595,14 @@ suggestion, feel free to open an issue or pull request. (Last updated: 2026-06-2
   - Human escalation via Telegram for true blockers only
   - Repo is a live company: built its own landing page, Docker stack, and monitoring across 13 autonomous cycles
 
+- [IronClaw](https://github.com/IronSecCo/ironclaw) - Security-hardened runtime for
+  running LLM agents inside sealed gVisor sandboxes
+
+  13 stars · 2 forks · Go · AGPL-3.0
+
+  - Per-session gVisor sandbox with no network card by default
+  - Model API keys held host-side, never exposed to the agent
+  - Human-approval gateway for every privileged tool call, spawn, and egress host
+  - Encrypted control-plane queues and a full audit log
+  - Drop-in for LangChain, CrewAI, OpenAI Agents SDK, and Claude Agent SDK agents
 


### PR DESCRIPTION
Adds **IronClaw** to the Frameworks list.

[IronClaw](https://github.com/IronSecCo/ironclaw) is a security-hardened runtime for running LLM agents inside sealed gVisor sandboxes. It exists to answer the question most agent frameworks skip: when an agent runs untrusted, model-chosen code, whose machine is it on?

- Per-session gVisor sandbox, no network card by default
- Model API keys held host-side, never in the agent
- Human-approval gateway for every privileged tool call, spawn, and new egress host
- Encrypted control-plane queues and a full audit log
- Works as a sandboxed backend for LangChain, CrewAI, OpenAI Agents SDK, and Claude Agent SDK agents

Open source, AGPLv3 (Go). Matches the existing entry format (name, description, stats line, feature bullets).