### PR TITLE
Add protoAgent to Frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -594,3 +594,12 @@ suggestion, feel free to open an issue or pull request. (Last updated: 2026-07-1
   - Repo is a live company: built its own landing page, Docker stack, and monitoring across 13 autonomous cycles
 
 
+- [protoAgent](https://github.com/protoLabsAI/protoAgent) - A2A-native agent
+  template built on LangGraph
+
+  - Native Agent2Agent protocol (JSON-RPC, SSE streaming, task lifecycle) plus an OpenAI-compatible /v1 API
+  - GitHub template repo — fork and own the core instead of inheriting a kitchen-sink framework
+  - Extensible via drop-in, git-URL-installable plugins (tools, skills, subagents, routes, console views)
+  - Ships a React operator console, built-in eval harness, cost/observability tracing, and a scheduler
+
+


### PR DESCRIPTION
Adds [protoAgent](https://github.com/protoLabsAI/protoAgent) — an A2A-native agent template built on LangGraph. Native Agent2Agent protocol support (JSON-RPC, SSE, task lifecycle) plus an OpenAI-compatible /v1 API, git-URL-installable plugins instead of forking the core, a React operator console, and a built-in eval/cost-observability harness. MIT licensed.

Left off a stats line since I saw update_metrics.py fills stars/forks/language on merge.