### PR TITLE
Add Atomic Agent (local-first CLI/TUI coding agent)

### DIFF
--- a/README.md
+++ b/README.md
@@ -590,3 +590,11 @@ suggestion, feel free to open an issue or pull request. (Last updated: 2026-08-0
   - Repo is a live company: built its own landing page, Docker stack, and monitoring across 13 autonomous cycles
 
 
+- [Atomic Agent](https://github.com/AtomicBot-ai/atomic-agent) - Local-first CLI and TUI
+  coding agent that runs open-weight models entirely on your machine
+
+  - Runs open-weight models locally via a llama.cpp fork, no account or API key required
+  - 56 built-in tools spanning browser, filesystem, git, memory, and vision
+  - Model Context Protocol (MCP) support for external integrations
+  - Five-layer local memory system
+  - Cross-platform support for macOS, Linux, and Windows


### PR DESCRIPTION
Hi! I'm the CPO of Atomic Agent — thank you for maintaining this list, it's a really clean, focused collection of agent frameworks. Our team would be thrilled to be part of it.

**Atomic Agent** is a local-first CLI and TUI coding agent that runs open-weight models entirely on your machine through a llama.cpp fork, with no account or API key required. It ships 56 built-in tools (browser, filesystem, git, memory, vision), supports MCP, uses a five-layer local memory system, and runs on macOS, Linux, and Windows.

I added a single entry under `## Frameworks`, matching your existing bullet + sub-bullet formatting.

Links:
- GitHub: https://github.com/AtomicBot-ai/atomic-agent (MIT, ~2k stars)
- Website: https://atomicagent.io
- Docs: https://atomicagent.io/docs

Happy to tweak the description or formatting to fit your conventions. Thanks again!
