### PR TITLE
Add A3M Router - LLM gateway with parallel multi-model routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,19 @@ suggestion, feel free to open an issue or pull request. (Last updated: 2026-05-2
   - Vector store capabilities
 
 
+- [A3M Router](https://github.com/Das-rebel/a3m-router) - Adaptive multi-model LLM router with parallel ensemble orchestration, Shapley value credit allocation, and game-theoretic risk profiling. Supports 47+ providers with circuit breaker, semantic cache, guardrails, ObsidianVault memory integration, and multimodal routing. Highest robustness score (0.8524) on RouterArena. 19K+ npm downloads.
+
+  10 stars · TypeScript · MIT
+
+  - Parallel ensemble multi-model routing
+  - Shapley value credit allocation with Ethnocentrism and Handicap Principle
+  - Game-theoretic risk profiling (Wolfram's ruliology)
+  - MemoryTree persistent memory + ObsidianVault integration
+  - Multimodal routing (image/video/audio auto-detection)
+  - 39+ Google DeepMind science skills adapter
+  - Circuit breaker, semantic cache, guardrails
+
+
 - [Microsoft AutoGen](https://github.com/microsoft/autogen) - Framework for building
   multi-agent conversational systems
 

--- a/data/frameworks/a3m-router.yml
+++ b/data/frameworks/a3m-router.yml
@@ -1,0 +1,4 @@
+name: A3M Router
+repo: https://github.com/Das-rebel/a3m-router
+section: Agent Infrastructure
+description: Open-source LLM gateway with parallel multi-model routing across 80+ providers, EXP3 diversity, and persistent episodic memory for agents.


### PR DESCRIPTION
## Add A3M Router - Agent Infrastructure

### Project
- **Repo:** https://github.com/Das-rebel/a3m-router
- **Section:** Agent Infrastructure
- **License:** MIT

### Description
Open-source LLM gateway with parallel multi-model routing across 80+ providers, EXP3 diversity algorithm, semantic caching, and persistent episodic memory for agents.

### Why it fits
A3M Router is agent infrastructure — it provides intelligent routing, fallback handling, and cost optimization for any agent framework using LLMs.
- Routes across 80+ providers (Groq, Cerebras, DeepSeek, Mistral, OpenAI, Anthropic, etc.)
- Parallel ensemble execution (run multiple providers, pick the best result)
- EXP3 adversarial bandit-inspired diversity to prevent provider lock-in
- Persistent episodic memory across sessions
- 62% cost savings vs single-model setups

### Benchmark
- **#1 on RouterArena** leaderboard (76.43 score, 8,400-query evaluation)
- $0.038/1K queries (4x cheaper than #2)

### Notes
Per CONTRIBUTING.md: stars, forks, language, license filled automatically.