### PR TITLE
Add OpenDraft to Domain-Specific Agents

### DIFF
--- a/data/frameworks/opendraft.yml
+++ b/data/frameworks/opendraft.yml
@@ -1,0 +1,4 @@
+name: OpenDraft
+repo: https://github.com/federicodeponte/opendraft
+section: Domain-Specific Agents
+description: Multi-agent research-paper writer with verified citations


### PR DESCRIPTION
Adds **OpenDraft** to *Domain-Specific Agents*.

OpenDraft is an open-source (MIT) multi-agent system that turns a topic into a full academic research paper. 18 specialized agents research, structure, write, and verify — every citation is checked against real academic databases (OpenAlex, Crossref, Semantic Scholar), so references are real rather than hallucinated.

- Repo: https://github.com/federicodeponte/opendraft (380★, MIT, active)
- Section: Domain-Specific Agents (agents built for one field — academic research)
- Description (57 chars): `Multi-agent research-paper writer with verified citations`

Verified locally against `python update_metrics.py --check` → *entries valid*. Single entry, resolves, not archived, pushed within 12 months, no duplicate.