### PR TITLE
Add agent-sdk-go

### DIFF
--- a/data/frameworks/agent-sdk-go.yml
+++ b/data/frameworks/agent-sdk-go.yml
@@ -1,0 +1,4 @@
+name: agent-sdk-go
+repo: https://github.com/agenticenv/agent-sdk-go
+section: Core Frameworks
+description: Framework for building stateful AI agents in Go


### PR DESCRIPTION
Adds `agent-sdk-go` framework under Core Frameworks.

* [x] Validated `data/frameworks/agent-sdk-go.yml` formatting
* [x] Description is under 60 characters (47 chars)
* [x] Repository is open source (Apache 2.0)