### PR TITLE
Add SandBase Harness to agent infrastructure

### DIFF
--- a/data/frameworks/sandbase-harness.yml
+++ b/data/frameworks/sandbase-harness.yml
@@ -1,0 +1,4 @@
+name: SandBase Harness
+repo: https://github.com/sandbaseai/sandbase-harness
+section: Agent Infrastructure
+description: Self-hosted runtime and MCP bridge for managed agents


### PR DESCRIPTION
## Add SandBase Harness

SandBase Harness is a self-hosted runtime and MCP bridge for managed agents.

- Repository: https://github.com/sandbaseai/sandbase-harness
- Section: Agent Infrastructure
- Description is 55 characters and follows the repository's one-file data format
- `python3 update_metrics.py --check` passed
- `python3 tests/test_update_metrics.py` passed (16/16)

Disclosure: I maintain/contribute to SandBase Harness.
