### PR TITLE
feat: add SandBase Harness

### DIFF
--- a/data/frameworks/sandbase-harness.yml
+++ b/data/frameworks/sandbase-harness.yml
@@ -1,0 +1,4 @@
+name: SandBase Harness
+repo: https://github.com/sandbaseai/sandbase-harness
+section: Agent Infrastructure
+description: Persistent agent runtime with MCP and governed execution


### PR DESCRIPTION
## Summary
- add SandBase Harness to Agent Infrastructure
- use the repository’s single-file data format and a concise 60-character description

The project is an open-source agent runtime and MCP server. The entry is source-backed and does not imply a hosted-service endorsement or security certification.