### PR TITLE
Add project: mloda

### DIFF
--- a/data/frameworks/mloda.yml
+++ b/data/frameworks/mloda.yml
@@ -1,0 +1,4 @@
+name: mloda
+repo: https://github.com/mloda-ai/mloda
+section: Retrieval & Data
+description: Plugin-based feature engineering for agent data pipelines


### PR DESCRIPTION
Adds mloda (https://github.com/mloda-ai/mloda) under Retrieval & Data: a plugin-based feature engineering framework used to build data pipelines that agents and RAG systems read from. Apache-2.0, 81 stars, pushed within the last 12 months.