### PR TITLE
Add Attenu Guard — narrows agent permissions across handoffs, verified offline

### DIFF
--- a/data/frameworks/attenu-guard.yml
+++ b/data/frameworks/attenu-guard.yml
@@ -1,0 +1,4 @@
+name: Attenu Guard
+repo: https://github.com/attenu-io/attenu-guard
+section: Safety, Security & Evaluation
+description: Narrows agent permissions across handoffs, verified offline


### PR DESCRIPTION
Disclosure: I maintain attenu-guard.

One file, `data/frameworks/attenu-guard.yml`, under Safety, Security & Evaluation, in the shape of the existing entries.

Attenu Guard runs inside the agent process. When an agent delegates to a sub-agent, the sub-agent can only hold permissions its parent already holds. Every decision and delegation goes to a signed, hash-chained log that a reviewer can verify offline. Apache-2.0, PyPI `attenu-guard` 0.10.0.