### PR TITLE
Add YYLO CLI to CLI Agent Harnesses

### DIFF
--- a/data/frameworks/yylo-cli.yml
+++ b/data/frameworks/yylo-cli.yml
@@ -1,0 +1,4 @@
+name: YYLO CLI
+repo: https://github.com/yylo-dev/yylo
+section: CLI Agent Harnesses
+description: Kanban-driven orchestrator for CLI coding agents


### PR DESCRIPTION
Disclosure: I maintain YYLO CLI.

One file, `data/frameworks/yylo-cli.yml`, under CLI Agent Harnesses, in the shape of the existing entries.

YYLO (`yylo` / `yy`) is a command-line orchestrator for coding agents: Kanban task state, typed validation and merge orchestration, and receipt-backed repository changes across agents like Claude Code, Codex, and Gemini CLI. MIT-licensed, installable via `npm i -g @yylo/cli`, 56 stars, pushed daily.

Meets the stated requirements: repo resolves, not archived, pushed within 12 months, ≥25 stars, not a duplicate, description ≤60 chars.