### PR TITLE
Add AIWG

### DIFF
--- a/data/frameworks/aiwg.yml
+++ b/data/frameworks/aiwg.yml
@@ -1,0 +1,4 @@
+name: AIWG
+repo: https://github.com/jmagly/aiwg
+section: CLI Agent Harnesses
+description: Project-owned workflows for coding agents across platforms


### PR DESCRIPTION
## Summary

Add AIWG to the CLI Agent Harnesses section. AIWG deploys project-owned workflows and supporting context across coding-agent platforms.

## Requirements checked

- Repository resolves and is not archived
- Pushed within the last 12 months
- More than 25 stars
- No existing AIWG catalog entry, issue, or pull request found
- Description is 58 characters

## Validation

- `python3 tests/test_update_metrics.py` — 16/16 passed