### PR TITLE
docs: add Bifrost to agent infrastructure

### DIFF
--- a/data/frameworks/bifrost.yml
+++ b/data/frameworks/bifrost.yml
@@ -1,0 +1,4 @@
+name: Bifrost
+repo: https://github.com/maximhq/bifrost
+section: Agent Infrastructure
+description: OpenAI-compatible gateway for multi-provider agent routing


### PR DESCRIPTION
## Summary

- add Bifrost under Agent Infrastructure

Bifrost is an open-source, self-hosted AI gateway that provides an OpenAI-compatible endpoint for multi-provider agent routing. This entry follows the repository's existing one-file framework format and keeps the description within the documented 60-character limit.

Documentation: https://docs.getbifrost.ai/overview
